### PR TITLE
Fix link

### DIFF
--- a/source/docs/writing-addons/code-generation.md
+++ b/source/docs/writing-addons/code-generation.md
@@ -9,7 +9,7 @@ title: Code Generation
 
 # Code Generation
 
-All [CLI tools](../../authoring-builds/cli-tools.md) are implemented following a code generation approach
+All [CLI tools](../authoring-builds/cli-tools.md) are implemented following a code generation approach
 
 ## Names
 


### PR DESCRIPTION
Fix a dead link from http://www.nuke.build/docs/writing-addons/code-generation.html to http://www.nuke.build/docs/authoring-builds/cli-tools.html

As stated in https://github.com/nuke-build/nuke/issues/285, I could not build the documentation, so while I'm pretty confident I fixed the link, I could not verify it.